### PR TITLE
Mission creation logging typo

### DIFF
--- a/DZMS/Missions/AN2_Cargo_Drop.sqf
+++ b/DZMS/Missions/AN2_Cargo_Drop.sqf
@@ -16,7 +16,7 @@ local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _dotMarker = "DZMSDot" + str _mission;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -50,7 +50,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_AN2_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/APC_Mission.sqf
+++ b/DZMS/Missions/APC_Mission.sqf
@@ -8,7 +8,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -42,7 +42,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_APC_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/C130_Crash.sqf
+++ b/DZMS/Missions/C130_Crash.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_C130_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Construction_Site.sqf
+++ b/DZMS/Missions/Construction_Site.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_CONST_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Firebase.sqf
+++ b/DZMS/Missions/Firebase.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_FB_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/General_Store.sqf
+++ b/DZMS/Missions/General_Store.sqf
@@ -12,7 +12,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -46,7 +46,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_GS_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Helicopter_Crash.sqf
+++ b/DZMS/Missions/Helicopter_Crash.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]

--- a/DZMS/Missions/Helicopter_Landing.sqf
+++ b/DZMS/Missions/Helicopter_Landing.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_HL_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Humvee_Crash.sqf
+++ b/DZMS/Missions/Humvee_Crash.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_HUM_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Medical_Cache.sqf
+++ b/DZMS/Missions/Medical_Cache.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_MCACHE_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Medical_Camp.sqf
+++ b/DZMS/Missions/Medical_Camp.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_MCAMP_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Medical_Outpost.sqf
+++ b/DZMS/Missions/Medical_Outpost.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_MOP_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Squad.sqf
+++ b/DZMS/Missions/Squad.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_PS_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Stash_House.sqf
+++ b/DZMS/Missions/Stash_House.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_STASH_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Ural_Ambush.sqf
+++ b/DZMS/Missions/Ural_Ambush.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_URAL_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Weapons_Cache.sqf
+++ b/DZMS/Missions/Weapons_Cache.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_WCACHE_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 

--- a/DZMS/Missions/Weapons_Truck.sqf
+++ b/DZMS/Missions/Weapons_Truck.sqf
@@ -14,7 +14,7 @@ local _markerColor = ["ColorRed","ColorBlue"] select _hero;
 local _localized = ["STR_CL_MISSION_BANDIT","STR_CL_MISSION_HERO"] select _hero;
 local _startTime = diag_tickTime;
 
-diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];
+diag_log format["[DZMS]: %1 %2 starting at %3.",_aiType,_name,_coords];
 
 ////////////////////// Do not edit this section ///////////////////////////
 //[position,createMarker,setMarkerColor,setMarkerType,setMarkerShape,setMarkerBrush,setMarkerSize,setMarkerText,setMarkerAlpha]
@@ -48,7 +48,7 @@ while {!_playerNear && !_timeout} do {
 if (_timeout) exitWith {
 	[_mission, _aiType, _markerIndex, _posIndex] call DZMSAbortMission;
 	[_aiType,_localName,"STR_CL_DZMS_WT_FAIL"] call DZMSMessage;
-	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];
+	diag_log format["DZMS: %1 %2 aborted.",_aiType,_name];
 };
 //////////////////////////////// End //////////////////////////////////////
 


### PR DESCRIPTION
Fixed `diag_log format["[DZMS]: %1 %2 starting at %2.",_aiType,_name,_coords];` using name twice and got rid of extra variable `_coords` in `diag_log format["DZMS: %1 %2 aborted.",_aiType,_name,_coords];`